### PR TITLE
Panic if nil context is passed to the handler

### DIFF
--- a/handlers/transactional/contracts.go
+++ b/handlers/transactional/contracts.go
@@ -2,6 +2,7 @@ package transactional
 
 import (
 	"database/sql"
+	"errors"
 
 	"github.com/smartystreets/messaging/v3"
 )
@@ -31,3 +32,5 @@ type State struct {
 }
 
 type handlerFunc func(state State) messaging.Handler
+
+var errNilContext = errors.New("context must not be nil")

--- a/handlers/transactional/handler.go
+++ b/handlers/transactional/handler.go
@@ -16,6 +16,10 @@ type handler struct {
 }
 
 func (this handler) Handle(ctx context.Context, messages ...interface{}) {
+	if ctx == nil {
+		panic(errNilContext)
+	}
+
 	connection, err := this.connector.Connect(ctx)
 	if err != nil {
 		this.logger.Printf("[WARN] Unable to begin transaction [%s].", err)

--- a/handlers/transactional/handler_test.go
+++ b/handlers/transactional/handler_test.go
@@ -64,6 +64,10 @@ func (this *Fixture) handle() {
 	this.handler.Handle(this.ctx, this.messages...)
 }
 
+func (this *Fixture) TestNilPanic_ItShouldPanic() {
+	this.ctx = nil
+	this.So(this.handle, should.PanicWith, errNilContext)
+}
 func (this *Fixture) TestWhenOpeningConnectionFails_ItShouldPanic() {
 	this.connectError = errors.New("")
 


### PR DESCRIPTION
If provided a nil context, a panic will occur deep in the standard library database/sql package. The stack trace produced in this situation is difficult to interpret. This change aims to short-circuit the wasted debugging time.