### PR TITLE
Add exponential backoff with jitter to retry handler

### DIFF
--- a/handlers/retry/config.go
+++ b/handlers/retry/config.go
@@ -27,8 +27,15 @@ func (singleton) Timeout(value time.Duration) option {
 func (singleton) MaxTimeout(value time.Duration) option {
 	return func(this *handler) { this.maxTimeout = value }
 }
-func (singleton) Jitter(value float64) option {
-	return func(this *handler) { this.jitter = value }
+func (singleton) JitterFactor(value float64) option {
+	return func(this *handler) {
+		if value < 0 {
+			value = 0
+		} else if value > 1.0 {
+			value = 1.0
+		}
+		this.jitterFactor = value
+	}
 }
 
 func (singleton) MaxAttempts(value uint32) option {

--- a/handlers/retry/config.go
+++ b/handlers/retry/config.go
@@ -35,12 +35,7 @@ func (singleton) MaxBackoff(value time.Duration) option {
 }
 func (singleton) JitterFactor(value float64) option {
 	return func(this *handler) {
-		if value < 0 {
-			value = 0
-		} else if value > 1.0 {
-			value = 1.0
-		}
-		this.jitterFactor = value
+		this.jitterFactor = max(0.0, min(1.0, value))
 	}
 }
 

--- a/handlers/retry/config.go
+++ b/handlers/retry/config.go
@@ -21,11 +21,17 @@ var Options singleton
 type singleton struct{}
 type option func(*handler)
 
+// Deprecated: Timeout is deprecated in favor of Backoff
 func (singleton) Timeout(value time.Duration) option {
-	return func(this *handler) { this.minTimeout = value }
+	return Options.Backoff(value)
 }
-func (singleton) MaxTimeout(value time.Duration) option {
-	return func(this *handler) { this.maxTimeout = value }
+func (singleton) Backoff(value time.Duration) option {
+	return func(this *handler) {
+		this.minBackoff = value
+	}
+}
+func (singleton) MaxBackoff(value time.Duration) option {
+	return func(this *handler) { this.maxBackoff = value }
 }
 func (singleton) JitterFactor(value float64) option {
 	return func(this *handler) {
@@ -59,14 +65,14 @@ func (singleton) LogStackTrace(value bool) option {
 }
 
 func (singleton) defaults(options ...option) []option {
-	const defaultRetryTimeout = time.Second * 5
+	const defaultRetryBackoffDelay = time.Second * 5
 	const defaultMaxAttempts = 1<<32 - 1
 	const defaultLogStackTrace = true
 	var defaultLogger = nop{}
 	var defaultMonitor = nop{}
 
 	return append([]option{
-		Options.Timeout(defaultRetryTimeout),
+		Options.Backoff(defaultRetryBackoffDelay),
 		Options.MaxAttempts(defaultMaxAttempts),
 		Options.LogStackTrace(defaultLogStackTrace),
 		Options.Logger(defaultLogger),

--- a/handlers/retry/config.go
+++ b/handlers/retry/config.go
@@ -22,8 +22,15 @@ type singleton struct{}
 type option func(*handler)
 
 func (singleton) Timeout(value time.Duration) option {
-	return func(this *handler) { this.timeout = value }
+	return func(this *handler) { this.minTimeout = value }
 }
+func (singleton) MaxTimeout(value time.Duration) option {
+	return func(this *handler) { this.maxTimeout = value }
+}
+func (singleton) Jitter(value float64) option {
+	return func(this *handler) { this.jitter = value }
+}
+
 func (singleton) MaxAttempts(value uint32) option {
 	return func(this *handler) { this.maxAttempts = int(value) }
 }

--- a/handlers/retry/handler.go
+++ b/handlers/retry/handler.go
@@ -11,14 +11,14 @@ import (
 
 type handler struct {
 	messaging.Handler
-	minTimeout  time.Duration
-	maxTimeout  time.Duration
-	jitter      float64
-	maxAttempts int
-	logger      logger
-	monitor     monitor
-	stackTrace  bool
-	immediate   map[any]struct{}
+	minTimeout   time.Duration
+	maxTimeout   time.Duration
+	jitterFactor float64
+	maxAttempts  int
+	logger       logger
+	monitor      monitor
+	stackTrace   bool
+	immediate    map[any]struct{}
 }
 
 func (this handler) Handle(ctx context.Context, messages ...any) {
@@ -79,9 +79,9 @@ func (this handler) backoffDelay(attempt int) time.Duration {
 	backoff := this.minTimeout << min(attempt, 63)
 	delay := min(backoff, this.maxTimeout)
 
-	if this.jitter > 0 && this.jitter <= 1.0 {
-		jitterRange := float64(delay) * this.jitter
-		minDelay := float64(delay) * (1.0 - this.jitter)
+	if this.jitterFactor > 0 && this.jitterFactor <= 1.0 {
+		jitterRange := float64(delay) * this.jitterFactor
+		minDelay := float64(delay) * (1.0 - this.jitterFactor)
 		delay = time.Duration(minDelay + rand.Float64()*(2*jitterRange))
 	}
 

--- a/handlers/retry/handler.go
+++ b/handlers/retry/handler.go
@@ -81,7 +81,7 @@ func (this handler) backoffDelay(attempt int) time.Duration {
 
 	if this.jitterFactor > 0 && this.jitterFactor <= 1.0 {
 		jitterRange := float64(delay) * this.jitterFactor
-		minDelay := float64(delay) * (1.0 - this.jitterFactor)
+		minDelay := float64(delay) - jitterRange
 		delay = time.Duration(minDelay + rand.Float64()*(2*jitterRange))
 	}
 

--- a/handlers/retry/handler.go
+++ b/handlers/retry/handler.go
@@ -2,6 +2,7 @@ package retry
 
 import (
 	"context"
+	"math/rand/v2"
 	"runtime/debug"
 	"time"
 
@@ -10,7 +11,9 @@ import (
 
 type handler struct {
 	messaging.Handler
-	timeout     time.Duration
+	minTimeout  time.Duration
+	maxTimeout  time.Duration
+	jitter      float64
 	maxAttempts int
 	logger      logger
 	monitor     monitor
@@ -45,7 +48,7 @@ func (this handler) finally(ctx context.Context, attempt int, err any) bool {
 func (this handler) handleFailure(ctx context.Context, attempt int, err any) {
 	this.logFailure(attempt, err)
 	this.panicOnTooManyAttempts(attempt)
-	this.sleep(ctx, err)
+	this.sleep(ctx, attempt, err)
 }
 func (this handler) logFailure(attempt int, err any) {
 	if this.stackTrace {
@@ -59,13 +62,30 @@ func (this handler) panicOnTooManyAttempts(attempt int) {
 		panic(ErrMaxRetriesExceeded)
 	}
 }
-func (this handler) sleep(ctx context.Context, err any) {
+func (this handler) sleep(ctx context.Context, attempt int, err any) {
 	if _, contains := this.immediate[err]; contains {
 		return
 	}
-	timeoutCtx, timeoutCancel := context.WithTimeout(ctx, this.timeout)
+	timeoutCtx, timeoutCancel := context.WithTimeout(ctx, this.backoffDelay(attempt))
 	defer timeoutCancel()
 	<-timeoutCtx.Done()
+}
+
+func (this handler) backoffDelay(attempt int) time.Duration {
+	if attempt == 0 || this.maxTimeout == 0 {
+		return this.minTimeout
+	}
+
+	backoff := this.minTimeout << min(attempt, 63)
+	delay := min(backoff, this.maxTimeout)
+
+	if this.jitter > 0 && this.jitter <= 1.0 {
+		jitterRange := float64(delay) * this.jitter
+		minDelay := float64(delay) * (1.0 - this.jitter)
+		delay = time.Duration(minDelay + rand.Float64()*(2*jitterRange))
+	}
+
+	return delay
 }
 
 func isAlive(ctx context.Context) bool {

--- a/handlers/retry/handler.go
+++ b/handlers/retry/handler.go
@@ -11,8 +11,8 @@ import (
 
 type handler struct {
 	messaging.Handler
-	minTimeout   time.Duration
-	maxTimeout   time.Duration
+	minBackoff   time.Duration
+	maxBackoff   time.Duration
 	jitterFactor float64
 	maxAttempts  int
 	logger       logger
@@ -72,12 +72,12 @@ func (this handler) sleep(ctx context.Context, attempt int, err any) {
 }
 
 func (this handler) backoffDelay(attempt int) time.Duration {
-	if attempt == 0 || this.maxTimeout == 0 {
-		return this.minTimeout
+	if attempt == 0 || this.maxBackoff == 0 {
+		return this.minBackoff
 	}
 
-	backoff := this.minTimeout << min(attempt, 63)
-	delay := min(backoff, this.maxTimeout)
+	backoff := this.minBackoff << min(attempt, 63)
+	delay := min(backoff, this.maxBackoff)
 
 	if this.jitterFactor > 0 && this.jitterFactor <= 1.0 {
 		jitterRange := float64(delay) * this.jitterFactor

--- a/handlers/retry/handler_test.go
+++ b/handlers/retry/handler_test.go
@@ -146,9 +146,9 @@ func (this *Fixture) LongTestExponentialBackoff() {
 	this.noErrorAfterAttempt = 4
 	this.handler = New(this,
 		Options.MaxAttempts(3),
-		Options.Timeout(time.Millisecond*50),
-		Options.MaxTimeout(time.Millisecond*500),
-		Options.Jitter(0.0),
+		Options.Backoff(time.Millisecond*50),
+		Options.MaxBackoff(time.Millisecond*500),
+		Options.JitterFactor(0.0),
 		Options.Monitor(this),
 		Options.Logger(this),
 	)
@@ -166,9 +166,9 @@ func (this *Fixture) LongTestBackoffMaxTimeoutNotExceeded() {
 	this.noErrorAfterAttempt = 5
 	this.handler = New(this,
 		Options.MaxAttempts(4),
-		Options.Timeout(time.Millisecond*50),
-		Options.MaxTimeout(time.Millisecond*100),
-		Options.Jitter(0.0),
+		Options.Backoff(time.Millisecond*50),
+		Options.MaxBackoff(time.Millisecond*100),
+		Options.JitterFactor(0.0),
 		Options.Monitor(this),
 		Options.Logger(this),
 	)

--- a/handlers/retry/handler_test.go
+++ b/handlers/retry/handler_test.go
@@ -141,6 +141,47 @@ func (this *Fixture) TestWhenRecoveryGivesSpecifiedError_DoNotSleepAndRetryImmed
 	this.So(time.Since(started), should.BeLessThan, time.Millisecond*10)
 }
 
+func (this *Fixture) LongTestExponentialBackoff() {
+	this.handleError = errors.New("failed")
+	this.noErrorAfterAttempt = 4
+	this.handler = New(this,
+		Options.MaxAttempts(3),
+		Options.Timeout(time.Millisecond*50),
+		Options.MaxTimeout(time.Millisecond*500),
+		Options.Jitter(0.0),
+		Options.Monitor(this),
+		Options.Logger(this),
+	)
+
+	start := time.Now().UTC()
+	this.So(this.handle, should.NotPanic)
+	elapsed := time.Since(start)
+
+	expected := 50*time.Millisecond + 100*time.Millisecond + 200*time.Millisecond
+	this.So(elapsed, should.BeBetween, expected, expected+5*time.Millisecond)
+	this.So(this.monitoredAttemptCount, should.Equal, 3)
+}
+func (this *Fixture) LongTestBackoffMaxTimeoutNotExceeded() {
+	this.handleError = errors.New("failed")
+	this.noErrorAfterAttempt = 5
+	this.handler = New(this,
+		Options.MaxAttempts(4),
+		Options.Timeout(time.Millisecond*50),
+		Options.MaxTimeout(time.Millisecond*100),
+		Options.Jitter(0.0),
+		Options.Monitor(this),
+		Options.Logger(this),
+	)
+
+	start := time.Now().UTC()
+	this.handle()
+	elapsed := time.Since(start)
+
+	expected := 50*time.Millisecond + 100*time.Millisecond*3
+	this.So(elapsed, should.BeBetween, expected, expected+5*time.Millisecond)
+	this.So(this.monitoredAttemptCount, should.Equal, 4)
+}
+
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 func (this *Fixture) Handle(ctx context.Context, messages ...any) {


### PR DESCRIPTION
Proposal to add a backoff strategy (with jitter) to the retry handler. Adds two options and does not change existing behavior.